### PR TITLE
Foundry v11 compatibility fix (by coffiarts)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+## 2.0.1 (by coffiarts)
+* Foundry v11 compatibility (only trivial changes to module.json)
+
 ## 2.0.0
 * Add support for FoundryVTT V10, breaking compatibility with prior versions.
 

--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
     
     "manifestPlusVersion": "1.2.0",
     
-    "version": "2.0.0",
+    "version": "2.0.1",
     "author": "Ceane",
     "authors": [
         {
@@ -18,12 +18,18 @@
     "esmodules": [
         "ranger-fog.js"
     ],
-    
-    "dependencies": [
-        {
-            "name": "lib-wrapper"
-        }
-    ],
+    "relationships": {
+        "requires": [
+            {
+                "id": "lib-wrapper",
+                "type": "module",
+                "manifest": "https://github.com/ruipin/fvtt-lib-wrapper/releases/download/v1.12.13.0/module.json",
+                "compatibility": {
+                    "verified": "1.12.13.0"
+                }
+            }
+        ]
+    },
     "languages": [
         {
             "lang": "en",
@@ -34,7 +40,7 @@
 
     "compatibility": {
         "minimum": "10",
-        "verified": "10.288"
+        "verified": "11"
     },
 
     "media": [


### PR DESCRIPTION
Nothing but trivial adjustments to version and dpendency declarations in manifest file. Mod seems to be running fine under v11 anyway, but now thos unnecessary console errors should be gone.